### PR TITLE
Usando 3 column grid por padrão no footer

### DIFF
--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -22,7 +22,7 @@ const links: Array<FooterLink> = [
 ---
 
 <footer class="relative flex h-64 items-center justify-center">
-  <ul class="relative grid grid-cols-2 gap-8 sm:grid-cols-3">
+  <ul class="relative grid grid-cols-3 gap-8">
     {
       links.map((link) => (
         <li>


### PR DESCRIPTION
Aqui é mais uma sugestão/duvida que eu percebi no site, acredito que podemos seguir com 3 colunas por padrão para mobiles ?  Abaixo segue uma relação do antes e depois

| Antes | Depois |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/86631177/225660245-eea82880-dc5b-4f47-bfb7-134b661ee254.png) | ![image](https://user-images.githubusercontent.com/86631177/225660150-c2be8072-e21e-4bac-a88d-475ffddc966b.png) | 